### PR TITLE
Match DeferredRender in performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gemspec
 gem "rake", "~> 13.0"
 gem "minitest", "~> 5.16"
 gem "standard", "~> 1.3"
+gem "benchmark-ips"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    benchmark-ips (2.13.0)
     cgi (0.4.1)
     concurrent-ruby (1.2.3)
     erb (4.0.4)
@@ -66,6 +67,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  benchmark-ips
   minitest (~> 5.16)
   phlex-slotable!
   rake (~> 13.0)

--- a/benchmark/main.rb
+++ b/benchmark/main.rb
@@ -1,0 +1,105 @@
+require "benchmark"
+require "benchmark/ips"
+require_relative "../lib/phlex/slotable"
+
+class DeferredList < Phlex::HTML
+  include Phlex::DeferredRender
+
+  def initialize
+    @items = []
+  end
+
+  def template
+    if @header
+      h1(class: "header", &@header)
+    end
+
+    ul do
+      @items.each do |item|
+        li { render(item) }
+      end
+    end
+  end
+
+  def header(&block)
+    @header = block
+  end
+
+  def with_item(&content)
+    @items << content
+  end
+end
+
+class SlotableList < Phlex::HTML
+  include Phlex::Slotable
+
+  slot :header
+  slot :item, many: true
+
+  def template
+    if header_slot
+      h1(class: "header", &header_slot)
+    end
+
+    ul do
+      item_slots.each do |slot|
+        li { render(slot) }
+      end
+    end
+  end
+end
+
+class DeferredListExample < Phlex::HTML
+  def template
+    render DeferredList.new do |list|
+      list.header do
+        "Header"
+      end
+
+      list.with_item do
+        "One"
+      end
+
+      list.with_item do
+        "two"
+      end
+    end
+  end
+end
+
+class SlotableListExample < Phlex::HTML
+  def template
+    render SlotableList.new do |list|
+      list.with_header do
+        "Header"
+      end
+
+      list.with_item do
+        "One"
+      end
+
+      list.with_item do
+        "two"
+      end
+    end
+  end
+end
+
+puts RUBY_DESCRIPTION
+
+deferred_list = DeferredListExample.new.call
+slotable_list = SlotableListExample.new.call
+
+raise unless deferred_list == slotable_list
+
+Benchmark.bmbm do |x|
+  x.report("Deferred") { 1_000_000.times { DeferredListExample.new.call } }
+  x.report("Slotable") { 1_000_000.times { SlotableListExample.new.call } }
+end
+
+puts
+
+Benchmark.ips do |x|
+  x.report("Deferred") { DeferredListExample.new.call }
+  x.report("Slotable") { SlotableListExample.new.call }
+end


### PR DESCRIPTION
Previous code has performance penalty compared to DeferredRender. This changes will match Slotable performance with DeferredRender.

```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
                  user     system      total        real
Deferred      3.732848   0.003853   3.736701 (  3.746092)
Slotable Old  4.628438   0.005811   4.634249 (  4.640234)
Slotable New  3.685357   0.003766   3.689123 (  3.693959)


ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
Warming up --------------------------------------
            Deferred    26.779k i/100ms
        Slotable Old    21.636k i/100ms
        Slotable New    27.013k i/100ms
Calculating -------------------------------------
            Deferred    267.884k (± 0.6%) i/s -      1.366M in   5.098391s
        Slotable Old    216.193k (± 0.4%) i/s -      1.082M in   5.003961s
        Slotable New    270.082k (± 0.5%) i/s -      1.351M in   5.001001s
```